### PR TITLE
Ci

### DIFF
--- a/.github/workflows/publish-tp-pypi.yml
+++ b/.github/workflows/publish-tp-pypi.yml
@@ -1,0 +1,28 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [ master ] # Roda quando atualiza a master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout do código
+        uses: actions/checkout@v4
+
+      - name: Setup do Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Instalar dependências e buildar
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+
+      - name: Publicar no PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Token vem dos Secrets do repositório. Nunca colocar direto aqui.
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "browser-core"
-version = "1.1.1"
+version = "1.2.0"
 authors = [
     { name = "gabigolo" }
 ]


### PR DESCRIPTION
Adds a GitHub Actions workflow to automatically build and publish the package
to PyPI on every push to the 'master' branch.

This automates the release process, ensuring consistency and security by
using GitHub Secrets for the PyPI API token.