### PR TITLE
ci: consolidate workflows in release-and-publish.yml

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -26,7 +26,7 @@ jobs:
           commit_sha: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Show new tag
-        run:
+        run: |
           echo "Nova tag: ${{ steps.tag_version.outputs.new_tag }}"
 
       - name: Update version in pyproject.toml


### PR DESCRIPTION
- remove create-release-tag.yml and publish-to-pypi.yml
- add release-and-publish.yml unifying tag + PyPI publishing