### PR TITLE
ci: consolidate workflows in release-and-publish.yml

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -31,9 +31,9 @@ jobs:
 
       - name: Update version in pyproject.toml
         run: |
-          TAG_VERSION=${{ steps.tag_version.outputs.new_tag#v }}
-          # substitui mesmo com indentação
-          sed -i -E 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*".*"/version = "'$TAG_VERSION'"/' pyproject.toml
+          TAG_VERSION="${{ steps.tag_version.outputs.new_tag }}"
+          TAG_VERSION="${TAG_VERSION#v}"
+          sed -i -E 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*".*"/version = "'"$TAG_VERSION"'"/' pyproject.toml
 
       - name: Commit version bump
         run: |
@@ -41,7 +41,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml
           git commit -m "chore(release): set version to $TAG_VERSION [skip ci]" || true
-          git push origin HEAD
+          git push origin HEAD:refs/heads/master
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
- remove create-release-tag.yml and publish-to-pypi.yml
- add release-and-publish.yml unifying tag + PyPI publishing